### PR TITLE
Allow to skip deserialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -447,7 +447,7 @@ export const createEosioShipReader = async (config: EosioReaderConfig) => {
         )
         state.unconfirmedMessages = 0
       }
-    } catch (error) {
+    } catch (error: any) {
       errors$.next(error)
       stop()
     }


### PR DESCRIPTION
When I configured **fetch_block** to be equal false, I assumed that would skip deserialization of blocks _(because that was causing incompatibility errors in my case)_ -