### PR TITLE
Fix readyState not handled in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -430,7 +430,7 @@ export const createEosioShipReader = async (config: EosioReaderConfig) => {
     })
 
     const serializedRequest = serialize('request', ['get_blocks_request_v0', state.shipRequest], state.eosioTypes)
-    state.socket!.send(serializedRequest)
+    if (state.socket.readyState>0) state.socket.send(serializedRequest);
   })
 
   serializedMessages$.subscribe(async (message: EosioSocketMessage) => {


### PR DESCRIPTION
Fixed message subscription that cause crash. The socket may not be ready when send the first request in abiMessages$.subscribe. Added a check for if state.socket.readyState is upper 0 to send the request over the socket